### PR TITLE
fix Invalid Exclude build warning 

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -16,5 +16,6 @@ let package = Package(
     targets: [
         .target(
             name: "SwiftUITooltip"
+        )
     ]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -15,7 +15,6 @@ let package = Package(
     ],
     targets: [
         .target(
-            name: "SwiftUITooltip",
-            exclude: ["images"]),
+            name: "SwiftUITooltip"
     ]
 )


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/1756909/140970251-a92d247b-0996-4273-ae47-7ba669bcf240.png)

Note that SPM ignores files that are outside the Sources directory, so the `exclude` here is redundant