### PR TITLE
Add toggle to present and dismiss tooltip on demand

### DIFF
--- a/Sources/SwiftUITooltip/TooltipConfigurations/ArrowOnlyTooltipConfig.swift
+++ b/Sources/SwiftUITooltip/TooltipConfigurations/ArrowOnlyTooltipConfig.swift
@@ -40,6 +40,8 @@ public struct ArrowOnlyTooltipConfig: TooltipConfig {
     public var animationOffset: CGFloat = 10
     public var animationTime: Double = 1
 
+    public var transition: AnyTransition = .opacity
+
     public init() {}
 
     public init(side: TooltipSide) {

--- a/Sources/SwiftUITooltip/TooltipConfigurations/DefaultTooltipConfig.swift
+++ b/Sources/SwiftUITooltip/TooltipConfigurations/DefaultTooltipConfig.swift
@@ -40,6 +40,8 @@ public struct DefaultTooltipConfig: TooltipConfig {
     public var animationOffset: CGFloat = 10
     public var animationTime: Double = 1
 
+    public var transition: AnyTransition = .opacity
+
     public init() {}
 
     public init(side: TooltipSide) {

--- a/Sources/SwiftUITooltip/TooltipConfigurations/TooltipConfig.swift
+++ b/Sources/SwiftUITooltip/TooltipConfigurations/TooltipConfig.swift
@@ -39,4 +39,6 @@ public protocol TooltipConfig {
     var enableAnimation: Bool { get set }
     var animationOffset: CGFloat { get set }
     var animationTime: Double { get set }
+
+    var transition: AnyTransition { get set }
 }

--- a/Sources/SwiftUITooltip/TooltipModifier.swift
+++ b/Sources/SwiftUITooltip/TooltipModifier.swift
@@ -9,15 +9,15 @@ import SwiftUI
 
 struct TooltipModifier<TooltipContent: View>: ViewModifier {
     // MARK: - Uninitialised properties
-    var isEnabled: Binding<Bool>
+    var enabled: Binding<Bool>
     var config: TooltipConfig
     var content: TooltipContent
 
 
     // MARK: - Initialisers
 
-    init(isEnabled: Binding<Bool>, config: TooltipConfig, @ViewBuilder content: @escaping () -> TooltipContent) {
-        self.isEnabled = isEnabled
+    init(enabled: Binding<Bool>, config: TooltipConfig, @ViewBuilder content: @escaping () -> TooltipContent) {
+        self.enabled = enabled
         self.config = config
         self.content = content()
     }
@@ -191,7 +191,7 @@ struct TooltipModifier<TooltipContent: View>: ViewModifier {
 
     func body(content: Content) -> some View {
         content
-            .overlay(isEnabled.wrappedValue ? tooltipBody.transition(config.transition) : nil)            
+            .overlay(enabled.wrappedValue ? tooltipBody.transition(config.transition) : nil)
     }
 }
 
@@ -202,7 +202,7 @@ struct Tooltip_Previews: PreviewProvider {
         
         
         return VStack {
-            Text("Say...").tooltip(isEnabled: .constant(true), config: config) {
+            Text("Say...").tooltip(.constant(true), config: config) {
                 Text("Something nice!")
             }
         }.previewDevice(.init(stringLiteral: "iPhone 12 mini"))

--- a/Sources/SwiftUITooltip/TooltipModifier.swift
+++ b/Sources/SwiftUITooltip/TooltipModifier.swift
@@ -191,8 +191,7 @@ struct TooltipModifier<TooltipContent: View>: ViewModifier {
 
     func body(content: Content) -> some View {
         content
-            .overlay(isEnabled.wrappedValue ? tooltipBody : nil)
-            .transition(.opacity)
+            .overlay(isEnabled.wrappedValue ? tooltipBody.transition(.opacity) : nil)            
     }
 }
 

--- a/Sources/SwiftUITooltip/TooltipModifier.swift
+++ b/Sources/SwiftUITooltip/TooltipModifier.swift
@@ -179,7 +179,7 @@ struct TooltipModifier<TooltipContent: View>: ViewModifier {
                 }
                 .background(self.sizeMeasurer)
                     .overlay(self.arrowView)
-            }            
+            }
             .offset(x: self.offsetHorizontal(g), y: self.offsetVertical(g))
             .onAppear {
                 self.dispatchAnimation()
@@ -192,9 +192,7 @@ struct TooltipModifier<TooltipContent: View>: ViewModifier {
     func body(content: Content) -> some View {
         content
             .overlay(isEnabled.wrappedValue ? tooltipBody : nil)
-            .transition(
-                AnyTransition.opacity.combined(with: .scale(scale: 1.1))
-            )
+            .transition(.opacity)
     }
 }
 

--- a/Sources/SwiftUITooltip/TooltipModifier.swift
+++ b/Sources/SwiftUITooltip/TooltipModifier.swift
@@ -179,9 +179,8 @@ struct TooltipModifier<TooltipContent: View>: ViewModifier {
                 }
                 .background(self.sizeMeasurer)
                     .overlay(self.arrowView)
-            }
+            }            
             .offset(x: self.offsetHorizontal(g), y: self.offsetVertical(g))
-            .animation(.easeInOut)
             .onAppear {
                 self.dispatchAnimation()
             }
@@ -193,6 +192,9 @@ struct TooltipModifier<TooltipContent: View>: ViewModifier {
     func body(content: Content) -> some View {
         content
             .overlay(isEnabled.wrappedValue ? tooltipBody : nil)
+            .transition(
+                AnyTransition.opacity.combined(with: .scale(scale: 1.1))
+            )
     }
 }
 

--- a/Sources/SwiftUITooltip/TooltipModifier.swift
+++ b/Sources/SwiftUITooltip/TooltipModifier.swift
@@ -202,7 +202,7 @@ struct Tooltip_Previews: PreviewProvider {
         
         
         return VStack {
-            Text("Say...").tooltip(true, config: config) {
+            Text("Say...").tooltip(config: config) {
                 Text("Something nice!")
             }
         }.previewDevice(.init(stringLiteral: "iPhone 12 mini"))

--- a/Sources/SwiftUITooltip/TooltipModifier.swift
+++ b/Sources/SwiftUITooltip/TooltipModifier.swift
@@ -191,7 +191,7 @@ struct TooltipModifier<TooltipContent: View>: ViewModifier {
 
     func body(content: Content) -> some View {
         content
-            .overlay(isEnabled.wrappedValue ? tooltipBody.transition(.opacity) : nil)            
+            .overlay(isEnabled.wrappedValue ? tooltipBody.transition(config.transition) : nil)            
     }
 }
 

--- a/Sources/SwiftUITooltip/TooltipModifier.swift
+++ b/Sources/SwiftUITooltip/TooltipModifier.swift
@@ -9,14 +9,14 @@ import SwiftUI
 
 struct TooltipModifier<TooltipContent: View>: ViewModifier {
     // MARK: - Uninitialised properties
-    var enabled: Binding<Bool>
+    var enabled: Bool
     var config: TooltipConfig
     var content: TooltipContent
 
 
     // MARK: - Initialisers
 
-    init(enabled: Binding<Bool>, config: TooltipConfig, @ViewBuilder content: @escaping () -> TooltipContent) {
+    init(enabled: Bool, config: TooltipConfig, @ViewBuilder content: @escaping () -> TooltipContent) {
         self.enabled = enabled
         self.config = config
         self.content = content()
@@ -191,7 +191,7 @@ struct TooltipModifier<TooltipContent: View>: ViewModifier {
 
     func body(content: Content) -> some View {
         content
-            .overlay(enabled.wrappedValue ? tooltipBody.transition(config.transition) : nil)
+            .overlay(enabled ? tooltipBody.transition(config.transition) : nil)
     }
 }
 
@@ -202,7 +202,7 @@ struct Tooltip_Previews: PreviewProvider {
         
         
         return VStack {
-            Text("Say...").tooltip(.constant(true), config: config) {
+            Text("Say...").tooltip(true, config: config) {
                 Text("Something nice!")
             }
         }.previewDevice(.init(stringLiteral: "iPhone 12 mini"))

--- a/Sources/SwiftUITooltip/TooltipModifier.swift
+++ b/Sources/SwiftUITooltip/TooltipModifier.swift
@@ -9,13 +9,15 @@ import SwiftUI
 
 struct TooltipModifier<TooltipContent: View>: ViewModifier {
     // MARK: - Uninitialised properties
-
+    var isEnabled: Binding<Bool>
     var config: TooltipConfig
     var content: TooltipContent
 
+
     // MARK: - Initialisers
 
-    init(config: TooltipConfig, @ViewBuilder content: @escaping () -> TooltipContent) {
+    init(isEnabled: Binding<Bool>, config: TooltipConfig, @ViewBuilder content: @escaping () -> TooltipContent) {
+        self.isEnabled = isEnabled
         self.config = config
         self.content = content()
     }
@@ -190,7 +192,7 @@ struct TooltipModifier<TooltipContent: View>: ViewModifier {
 
     func body(content: Content) -> some View {
         content
-            .overlay(tooltipBody)
+            .overlay(isEnabled.wrappedValue ? tooltipBody : nil)
     }
 }
 
@@ -201,7 +203,7 @@ struct Tooltip_Previews: PreviewProvider {
         
         
         return VStack {
-            Text("Say...").tooltip(config: config) {
+            Text("Say...").tooltip(isEnabled: .constant(true), config: config) {
                 Text("Something nice!")
             }
         }.previewDevice(.init(stringLiteral: "iPhone 12 mini"))

--- a/Sources/SwiftUITooltip/TooltipViewExtension.swift
+++ b/Sources/SwiftUITooltip/TooltipViewExtension.swift
@@ -8,24 +8,24 @@
 import SwiftUI
 
 public extension View {
-    func tooltip<TooltipContent: View>(_ enabled: Binding<Bool> = .constant(true), @ViewBuilder content: @escaping () -> TooltipContent) -> some View {
+    func tooltip<TooltipContent: View>(_ enabled: Bool = true, @ViewBuilder content: @escaping () -> TooltipContent) -> some View {
         let config: TooltipConfig = DefaultTooltipConfig.shared
 
         return modifier(TooltipModifier(enabled: enabled, config: config, content: content))
     }
 
-    func tooltip<TooltipContent: View>(_ enabled: Binding<Bool> = .constant(true), config: TooltipConfig, @ViewBuilder content: @escaping () -> TooltipContent) -> some View {
+    func tooltip<TooltipContent: View>(_ enabled: Bool = true, config: TooltipConfig, @ViewBuilder content: @escaping () -> TooltipContent) -> some View {
         modifier(TooltipModifier(enabled: enabled, config: config, content: content))
     }
 
-    func tooltip<TooltipContent: View>(_ enabled: Binding<Bool> = .constant(true), side: TooltipSide, @ViewBuilder content: @escaping () -> TooltipContent) -> some View {
+    func tooltip<TooltipContent: View>(_ enabled: Bool = true, side: TooltipSide, @ViewBuilder content: @escaping () -> TooltipContent) -> some View {
         var config = DefaultTooltipConfig.shared
         config.side = side
 
         return modifier(TooltipModifier(enabled: enabled, config: config, content: content))
     }
     
-    func tooltip<TooltipContent: View>(_ enabled: Binding<Bool> = .constant(true), side: TooltipSide, config: TooltipConfig, @ViewBuilder content: @escaping () -> TooltipContent) -> some View {
+    func tooltip<TooltipContent: View>(_ enabled: Bool = true, side: TooltipSide, config: TooltipConfig, @ViewBuilder content: @escaping () -> TooltipContent) -> some View {
         var config = config
         config.side = side
 

--- a/Sources/SwiftUITooltip/TooltipViewExtension.swift
+++ b/Sources/SwiftUITooltip/TooltipViewExtension.swift
@@ -8,24 +8,24 @@
 import SwiftUI
 
 public extension View {
-    func tooltip<TooltipContent: View>(_ enabled: Binding<Bool>, @ViewBuilder content: @escaping () -> TooltipContent) -> some View {
+    func tooltip<TooltipContent: View>(_ enabled: Binding<Bool> = .constant(true), @ViewBuilder content: @escaping () -> TooltipContent) -> some View {
         let config: TooltipConfig = DefaultTooltipConfig.shared
 
         return modifier(TooltipModifier(enabled: enabled, config: config, content: content))
     }
 
-    func tooltip<TooltipContent: View>(_ enabled: Binding<Bool>, config: TooltipConfig, @ViewBuilder content: @escaping () -> TooltipContent) -> some View {
+    func tooltip<TooltipContent: View>(_ enabled: Binding<Bool> = .constant(true), config: TooltipConfig, @ViewBuilder content: @escaping () -> TooltipContent) -> some View {
         modifier(TooltipModifier(enabled: enabled, config: config, content: content))
     }
 
-    func tooltip<TooltipContent: View>(_ enabled: Binding<Bool>, side: TooltipSide, @ViewBuilder content: @escaping () -> TooltipContent) -> some View {
+    func tooltip<TooltipContent: View>(_ enabled: Binding<Bool> = .constant(true), side: TooltipSide, @ViewBuilder content: @escaping () -> TooltipContent) -> some View {
         var config = DefaultTooltipConfig.shared
         config.side = side
 
         return modifier(TooltipModifier(enabled: enabled, config: config, content: content))
     }
     
-    func tooltip<TooltipContent: View>(_ enabled: Binding<Bool>, side: TooltipSide, config: TooltipConfig, @ViewBuilder content: @escaping () -> TooltipContent) -> some View {
+    func tooltip<TooltipContent: View>(_ enabled: Binding<Bool> = .constant(true), side: TooltipSide, config: TooltipConfig, @ViewBuilder content: @escaping () -> TooltipContent) -> some View {
         var config = config
         config.side = side
 

--- a/Sources/SwiftUITooltip/TooltipViewExtension.swift
+++ b/Sources/SwiftUITooltip/TooltipViewExtension.swift
@@ -31,4 +31,18 @@ public extension View {
 
         return modifier(TooltipModifier(enabled: enabled, config: config, content: content))
     }
+
+    func tooltip<TooltipContent: View>(_ side: TooltipSide, @ViewBuilder content: @escaping () -> TooltipContent) -> some View {
+        var config = DefaultTooltipConfig.shared
+        config.side = side
+
+        return modifier(TooltipModifier(enabled: true, config: config, content: content))
+    }
+
+    func tooltip<TooltipContent: View>(_ side: TooltipSide, config: TooltipConfig, @ViewBuilder content: @escaping () -> TooltipContent) -> some View {
+        var config = config
+        config.side = side
+
+        return modifier(TooltipModifier(enabled: true, config: config, content: content))
+    }
 }

--- a/Sources/SwiftUITooltip/TooltipViewExtension.swift
+++ b/Sources/SwiftUITooltip/TooltipViewExtension.swift
@@ -8,27 +8,27 @@
 import SwiftUI
 
 public extension View {
-    func tooltip<TooltipContent: View>(isEnabled: Binding<Bool>, @ViewBuilder content: @escaping () -> TooltipContent) -> some View {
+    func tooltip<TooltipContent: View>(_ enabled: Binding<Bool>, @ViewBuilder content: @escaping () -> TooltipContent) -> some View {
         let config: TooltipConfig = DefaultTooltipConfig.shared
 
-        return modifier(TooltipModifier(isEnabled: isEnabled, config: config, content: content))
+        return modifier(TooltipModifier(enabled: enabled, config: config, content: content))
     }
 
-    func tooltip<TooltipContent: View>(isEnabled: Binding<Bool>, config: TooltipConfig, @ViewBuilder content: @escaping () -> TooltipContent) -> some View {
-        modifier(TooltipModifier(isEnabled: isEnabled, config: config, content: content))
+    func tooltip<TooltipContent: View>(_ enabled: Binding<Bool>, config: TooltipConfig, @ViewBuilder content: @escaping () -> TooltipContent) -> some View {
+        modifier(TooltipModifier(enabled: enabled, config: config, content: content))
     }
 
-    func tooltip<TooltipContent: View>(_ side: TooltipSide, isEnabled: Binding<Bool>, @ViewBuilder content: @escaping () -> TooltipContent) -> some View {
+    func tooltip<TooltipContent: View>(_ enabled: Binding<Bool>, side: TooltipSide, @ViewBuilder content: @escaping () -> TooltipContent) -> some View {
         var config = DefaultTooltipConfig.shared
         config.side = side
 
-        return modifier(TooltipModifier(isEnabled: isEnabled, config: config, content: content))
+        return modifier(TooltipModifier(enabled: enabled, config: config, content: content))
     }
     
-    func tooltip<TooltipContent: View>(_ side: TooltipSide, isEnabled: Binding<Bool>, config: TooltipConfig, @ViewBuilder content: @escaping () -> TooltipContent) -> some View {
+    func tooltip<TooltipContent: View>(_ enabled: Binding<Bool>, side: TooltipSide, config: TooltipConfig, @ViewBuilder content: @escaping () -> TooltipContent) -> some View {
         var config = config
         config.side = side
 
-        return modifier(TooltipModifier(isEnabled: isEnabled, config: config, content: content))
+        return modifier(TooltipModifier(enabled: enabled, config: config, content: content))
     }
 }

--- a/Sources/SwiftUITooltip/TooltipViewExtension.swift
+++ b/Sources/SwiftUITooltip/TooltipViewExtension.swift
@@ -8,27 +8,27 @@
 import SwiftUI
 
 public extension View {
-    func tooltip<TooltipContent: View>(@ViewBuilder content: @escaping () -> TooltipContent) -> some View {
+    func tooltip<TooltipContent: View>(isEnabled: Binding<Bool>, @ViewBuilder content: @escaping () -> TooltipContent) -> some View {
         let config: TooltipConfig = DefaultTooltipConfig.shared
 
-        return modifier(TooltipModifier(config: config, content: content))
+        return modifier(TooltipModifier(isEnabled: isEnabled, config: config, content: content))
     }
 
-    func tooltip<TooltipContent: View>(config: TooltipConfig, @ViewBuilder content: @escaping () -> TooltipContent) -> some View {
-        modifier(TooltipModifier(config: config, content: content))
+    func tooltip<TooltipContent: View>(isEnabled: Binding<Bool>, config: TooltipConfig, @ViewBuilder content: @escaping () -> TooltipContent) -> some View {
+        modifier(TooltipModifier(isEnabled: isEnabled, config: config, content: content))
     }
 
-    func tooltip<TooltipContent: View>(_ side: TooltipSide, @ViewBuilder content: @escaping () -> TooltipContent) -> some View {
+    func tooltip<TooltipContent: View>(_ side: TooltipSide, isEnabled: Binding<Bool>, @ViewBuilder content: @escaping () -> TooltipContent) -> some View {
         var config = DefaultTooltipConfig.shared
         config.side = side
 
-        return modifier(TooltipModifier(config: config, content: content))
+        return modifier(TooltipModifier(isEnabled: isEnabled, config: config, content: content))
     }
     
-    func tooltip<TooltipContent: View>(_ side: TooltipSide, config: TooltipConfig, @ViewBuilder content: @escaping () -> TooltipContent) -> some View {
+    func tooltip<TooltipContent: View>(_ side: TooltipSide, isEnabled: Binding<Bool>, config: TooltipConfig, @ViewBuilder content: @escaping () -> TooltipContent) -> some View {
         var config = config
         config.side = side
 
-        return modifier(TooltipModifier(config: config, content: content))
+        return modifier(TooltipModifier(isEnabled: isEnabled, config: config, content: content))
     }
 }


### PR DESCRIPTION
### What
This change updates the tooltip api to allow on demand presentation and dismissal of the tooltip. 
Addresses feature request: https://github.com/quassum/SwiftUI-Tooltip/issues/20

### Changes
- Add `isEnabled: Binding<Bool>` to `TooltipModifier` and update the tooltip View extension api to include `isEnabled`
- Remove implicit `.animation(.easeInOut)` in favor of `.transition` to allow developers the option to present and dismiss with animations.

### Example

https://user-images.githubusercontent.com/729622/164873492-5a1ae5e3-c963-4d29-b667-c0f7557eaa6b.mp4


