### PR TITLE
27:  Border not visible on self sized tooltip

### DIFF
--- a/Sources/SwiftUITooltip/TooltipModifier.swift
+++ b/Sources/SwiftUITooltip/TooltipModifier.swift
@@ -179,14 +179,7 @@ struct TooltipModifier<TooltipContent: View>: ViewModifier {
             ZStack {
                 RoundedRectangle(cornerRadius: config.borderRadius)
                     .stroke(config.borderWidth == 0 ? Color.clear : config.borderColor)
-                    .frame(
-                        minWidth: contentWidth,
-                        idealWidth: contentWidth,
-                        maxWidth: config.width,
-                        minHeight: contentHeight,
-                        idealHeight: contentHeight,
-                        maxHeight: config.height
-                    )
+                    .frame(width: contentWidth, height: contentHeight)
                     .background(
                         RoundedRectangle(cornerRadius: config.borderRadius)
                             .foregroundColor(config.backgroundColor)


### PR DESCRIPTION
Fix the bug on issue 27:
The content width and content height  are calculated from the tooltip content size or from the given size, so we can always set the frame with `.frame(width: contentWidth, height: contentHeight)`